### PR TITLE
Filter out Monzo active card checks

### DIFF
--- a/internal/api/monzo/types.go
+++ b/internal/api/monzo/types.go
@@ -75,6 +75,7 @@ type Transaction struct {
 	Merchant        *Merchant     `json:"merchant"`
 	CounterParty    *CounterParty `json:"counterparty"`
 	DeclineReason   string        `json:"decline_reason"`
+	Metadata        map[string]string
 }
 
 func (t *Transaction) UnmarshalJSON(data []byte) error {

--- a/internal/export/monzo.go
+++ b/internal/export/monzo.go
@@ -224,6 +224,11 @@ func (m *monzoTransactionExporter) fetchTransactions(ctx context.Context, accoun
 				latest = transaction
 			}
 
+			isActiveCardCheck := transaction.Amount.MinorUnit == 0 && transaction.Metadata["notes"] == "Active card check"
+			if isActiveCardCheck {
+				continue
+			}
+
 			isNotDeclined := transaction.DeclineReason == ""
 			inDesiredDateRange := endDate.IsZero() || !transaction.CreatedAt.After(endDate)
 


### PR DESCRIPTION
Active card checks are included in the Monzo `transactions` API. These manifest as a 0 amount payment, unsettled, and with metadata "Active card check". 

Lets remove these from the exported transactions, because they aren't included in the Monzo spending report.