### PR TITLE
Fix Monzo transactions created on end date not included in export output

### DIFF
--- a/internal/export/monzo_test.go
+++ b/internal/export/monzo_test.go
@@ -122,28 +122,6 @@ func TestExportMonzoTransactions(t *testing.T) {
 						Currency:  "EUR",
 					},
 				},
-				{
-					Description: "settled",
-					SettledAt:   &now,
-					Amount: domain.Money{
-						MinorUnit: 276,
-						Currency:  "GBP",
-					},
-				},
-			},
-			expectedTransactions: []*domain.Transaction{
-				{
-					Amount: domain.Money{
-						MinorUnit: 276,
-						Currency:  "GBP",
-					},
-					Reference: "settled",
-					Category:  "",
-					CreatedAt: time.Time{},
-					IsDeposit: false,
-					BankName:  "Monzo",
-					Notes:     "",
-				},
 			},
 		},
 		"excludes active card checks": {
@@ -159,6 +137,26 @@ func TestExportMonzoTransactions(t *testing.T) {
 						Currency:  "USD",
 					},
 					SettledAt: nil,
+					Metadata: map[string]string{
+						"notes": "Active card check",
+					},
+				},
+			},
+		},
+		"excludes transactions created tomorrow": {
+			transactions: []*monzo.Transaction{
+				{
+					Description: "created tomorrow",
+					Amount: domain.Money{
+						MinorUnit: 0,
+						Currency:  "GBP",
+					},
+					LocalAmount: domain.Money{
+						MinorUnit: 0,
+						Currency:  "USD",
+					},
+					SettledAt: nil,
+					CreatedAt: now.AddDate(0, 0, 1),
 					Metadata: map[string]string{
 						"notes": "Active card check",
 					},

--- a/internal/export/monzo_test.go
+++ b/internal/export/monzo_test.go
@@ -164,7 +164,33 @@ func TestExportMonzoTransactions(t *testing.T) {
 					},
 				},
 			},
-			expectedTransactions: []*domain.Transaction{},
+		},
+		"includes transactions created on today": {
+			transactions: []*monzo.Transaction{
+				{
+					Description: "settled",
+					SettledAt:   &now,
+					CreatedAt:   now,
+					Amount: domain.Money{
+						MinorUnit: 276,
+						Currency:  "GBP",
+					},
+				},
+			},
+			expectedTransactions: []*domain.Transaction{
+				{
+					Amount: domain.Money{
+						MinorUnit: 276,
+						Currency:  "GBP",
+					},
+					Reference: "settled",
+					Category:  "",
+					CreatedAt: time.Time{},
+					IsDeposit: false,
+					BankName:  "Monzo",
+					Notes:     "",
+				},
+			},
 		},
 	}
 	for name, test := range tests {

--- a/internal/export/monzo_test.go
+++ b/internal/export/monzo_test.go
@@ -185,7 +185,7 @@ func TestExportMonzoTransactions(t *testing.T) {
 					},
 					Reference: "settled",
 					Category:  "",
-					CreatedAt: time.Time{},
+					CreatedAt: now,
 					IsDeposit: false,
 					BankName:  "Monzo",
 					Notes:     "",


### PR DESCRIPTION
This occurs because the end date is `2025-07-19 00:00:00 +0000 UTC` meaning that transactions that occurred during the day, e.g. `2025-07-18 11:03:23.987 +0000 UTC`, would be excluded because `transaction.CreatedAt.After(endDate)` would return `false`.