### PR TITLE
Simplify rest client

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -18,30 +18,21 @@ const (
 	defaultMaxRetryWaitTime = 10 * time.Second
 )
 
-type Client interface {
-	ExecuteRequest(ctx context.Context, method, url string, values url.Values, result any) (*resty.Response, error)
-}
+type Option func(*resty.Client)
 
-type BaseClient struct {
-	resty               *resty.Client
-	errorUnmarshallerFn func(r *resty.Response) error
-}
-
-type Option func(*BaseClient)
-
-func New(baseURL string, httpClient *http.Client, opts ...Option) *BaseClient {
-	c := &BaseClient{}
-	c.resty = resty.NewWithClient(httpClient).
+func New(baseURL string, httpClient *http.Client, opts ...Option) *resty.Client {
+	client := resty.NewWithClient(httpClient).
 		SetBaseURL(baseURL).
 		SetTimeout(defaultTimeout).
 		SetRetryCount(defaultRetryCount).
 		SetRetryWaitTime(defaultRetryWaitTime).
 		SetRetryMaxWaitTime(defaultMaxRetryWaitTime).
-		AddResponseMiddleware(func(c *resty.Client, r *resty.Response) error {
+		AddResponseMiddleware(func(client *resty.Client, r *resty.Response) error {
 			startTime := r.Request.Time
 			endTime := r.ReceivedAt()
 
 			req := r.Request
+
 			zerolog.Ctx(req.Context()).Debug().
 				Str("http.url", req.URL).
 				Str("http.method", req.Method).
@@ -52,7 +43,8 @@ func New(baseURL string, httpClient *http.Client, opts ...Option) *BaseClient {
 			return nil
 		}).
 		AddRetryConditions(func(r *resty.Response, err error) bool {
-			return err != nil || r.StatusCode() >= 500
+			retry := err != nil || r.StatusCode() >= 500
+			return retry
 		})
 
 	for _, opt := range opts {
@@ -60,49 +52,50 @@ func New(baseURL string, httpClient *http.Client, opts ...Option) *BaseClient {
 			continue
 		}
 
-		opt(c)
+		opt(client)
 	}
 
-	return c
+	return client
 }
 
 func WithAuthToken(authToken string) Option {
-	return func(c *BaseClient) {
-		c.resty.SetHeader("Authorization", authToken)
+	return func(c *resty.Client) {
+		c.SetHeader("Authorization", authToken)
 	}
 }
 
 func WithBaseURL(url string) Option {
-	return func(c *BaseClient) {
-		c.resty.SetBaseURL(url)
+	return func(c *resty.Client) {
+		c.SetBaseURL(url)
 	}
 }
 
-func WithErrorUnmarshaller(unmarshallerFn func(r *resty.Response) error) Option {
-	return func(c *BaseClient) {
-		c.errorUnmarshallerFn = unmarshallerFn
+func WithError[E error]() Option {
+	return func(c *resty.Client) {
+		var err E
+		c.SetError(&err)
 	}
 }
 
-func (c *BaseClient) ExecuteRequest(ctx context.Context, method, url string, values url.Values, result any) (*resty.Response, error) {
-	req := c.resty.R().
+func ExecuteRequest[T any](ctx context.Context, client *resty.Client, method, url string, values url.Values) (*T, error) {
+	var result T
+
+	resp, err := client.R().
 		SetContext(ctx).
-		SetResult(result).
+		SetResult(&result).
 		SetUnescapeQueryParams(false).
-		SetQueryParamsFromValues(values)
-
-	resp, err := req.Execute(method, url)
+		SetQueryParamsFromValues(values).
+		Execute(method, url)
 	if err != nil {
-		return resp, fmt.Errorf("%s %s failed: %w", method, resp.Request.URL, err)
+		return nil, fmt.Errorf("%s %s failed: %w", method, resp.Request.URL, err)
 	}
 
 	if resp.IsError() {
-		if c.errorUnmarshallerFn != nil {
-			return nil, c.errorUnmarshallerFn(resp)
+		if err, ok := resp.Error().(error); ok {
+			return nil, err
 		}
-
-		return nil, fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("http %d: %s", resp.StatusCode(), resp.String())
 	}
 
-	return resp, nil
+	return &result, nil
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -18,7 +19,7 @@ const (
 )
 
 type Client interface {
-	ExecuteRequest(ctx context.Context, method, url string, params map[string]string, result any) (*resty.Response, error)
+	ExecuteRequest(ctx context.Context, method, url string, values url.Values, result any) (*resty.Response, error)
 }
 
 type BaseClient struct {
@@ -83,14 +84,12 @@ func WithErrorUnmarshaller(unmarshallerFn func(r *resty.Response) error) Option 
 	}
 }
 
-func (c *BaseClient) ExecuteRequest(ctx context.Context, method, url string, params map[string]string, result any) (*resty.Response, error) {
+func (c *BaseClient) ExecuteRequest(ctx context.Context, method, url string, values url.Values, result any) (*resty.Response, error) {
 	req := c.resty.R().
 		SetContext(ctx).
 		SetResult(result).
-		SetUnescapeQueryParams(false)
-	for key, value := range params {
-		req.SetQueryParam(key, value)
-	}
+		SetUnescapeQueryParams(false).
+		SetQueryParamsFromValues(values)
 
 	resp, err := req.Execute(method, url)
 	if err != nil {

--- a/internal/api/monzo/monzo.go
+++ b/internal/api/monzo/monzo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -88,11 +89,10 @@ func (c *client) FetchPots(ctx context.Context, accountID AccountID) ([]*Pot, er
 		Pots []*Pot `json:"pots"`
 	}
 
-	queryParams := map[string]string{
-		"current_account_id": string(accountID),
-	}
+	values := url.Values{}
+	values.Add("current_account_id", string(accountID))
 
-	_, err := c.api.ExecuteRequest(ctx, http.MethodGet, getPotsRoute, queryParams, &result)
+	_, err := c.api.ExecuteRequest(ctx, http.MethodGet, getPotsRoute, values, &result)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch pots: %w", err)
 	}
@@ -149,30 +149,29 @@ func (c *client) FetchTransactionsSince(ctx context.Context, opts FetchTransacti
 		Transactions []*Transaction `json:"transactions"`
 	}
 
-	queryParams := map[string]string{
-		"account_id": string(opts.AccountID),
-		"expand[]":   "merchant",
-	}
+	values := url.Values{}
+	values.Add("account_id", string(opts.AccountID))
+	values.Add("expand[]", "merchant")
 
 	if opts.Limit == 0 {
 		opts.Limit = maxResultPerPage
 	}
 
 	if opts.Limit != 0 {
-		queryParams["limit"] = strconv.Itoa(opts.Limit)
+		values.Add("limit", strconv.Itoa(opts.Limit))
 	}
 
 	if !opts.End.IsZero() {
-		queryParams["before"] = opts.End.Format(time.RFC3339)
+		values.Add("before", opts.End.Format(time.RFC3339))
 	}
 
 	if opts.SinceID == "" {
-		queryParams["since"] = opts.Start.Format(time.RFC3339)
+		values.Add("since", opts.Start.Format(time.RFC3339))
 	} else {
-		queryParams["since"] = string(opts.SinceID)
+		values.Add("since", string(opts.SinceID))
 	}
 
-	_, err := c.api.ExecuteRequest(ctx, http.MethodGet, getTransactionsRoute, queryParams, &result)
+	_, err := c.api.ExecuteRequest(ctx, http.MethodGet, getTransactionsRoute, values, &result)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch transactions: %w", err)
 	}

--- a/internal/api/monzo/types.go
+++ b/internal/api/monzo/types.go
@@ -124,9 +124,8 @@ func (t *Transaction) UnmarshalJSON(data []byte) error {
 }
 
 type Error struct {
-	HTTPStatus int
-	Code       string `json:"code"`
-	Message    string `json:"message"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
 /*
@@ -135,22 +134,5 @@ Error (statusCode=400, code=bad_request.invalid_time_range, message=The time ran
 Error (statusCode=403, code=forbidden.verification_required, message=Verification required) when requesting old transactions.
 */
 func (err Error) Error() string {
-	return fmt.Sprintf("%s (http status=%d)", err.Message, err.HTTPStatus)
-}
-
-func UnmarshalError(status int, body []byte) error {
-	if len(body) != 0 {
-		apiError := Error{}
-		if err := json.Unmarshal(body, &apiError); err == nil && apiError.Code != "" {
-			apiError.HTTPStatus = status
-		}
-
-		return apiError
-	}
-
-	return Error{
-		HTTPStatus: status,
-		Code:       "unknown",
-		Message:    "unknown",
-	}
+	return fmt.Sprintf("%s (code=%s)", err.Message, err.Code)
 }

--- a/internal/api/starling/starling.go
+++ b/internal/api/starling/starling.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/HallyG/fingrab/internal/api"
@@ -147,16 +148,15 @@ func (c *client) FetchTransactionsSince(ctx context.Context, opts FetchTransacti
 		FeedItems []*FeedItem `json:"feedItems"`
 	}
 
-	queryParams := map[string]string{
-		"minTransactionTimestamp": opts.Start.Format(time.RFC3339),
-	}
+	values := url.Values{}
+	values.Add("minTransactionTimestamp", opts.Start.Format(time.RFC3339))
 	if !opts.End.IsZero() {
-		queryParams["maxTransactionTimestamp"] = opts.End.Format(time.RFC3339)
+		values.Add("maxTransactionTimestamp", opts.End.Format(time.RFC3339))
 	}
 
 	url := fmt.Sprintf(getTransactionsRoute, opts.AccountID, opts.CategoryID)
 
-	_, err := c.api.ExecuteRequest(ctx, http.MethodGet, url, queryParams, &result)
+	_, err := c.api.ExecuteRequest(ctx, http.MethodGet, url, values, &result)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch transactions: %w", err)
 	}

--- a/internal/api/starling/testdata/api/savings-goals.json
+++ b/internal/api/starling/testdata/api/savings-goals.json
@@ -5,7 +5,7 @@
             "name": "Trip to Paris",
             "target": {
               "currency": "GBP",
-              "minorUnits": 123456
+              "minorUnits": 123457
             },
             "totalSaved": {
               "currency": "GBP",

--- a/internal/api/starling/types.go
+++ b/internal/api/starling/types.go
@@ -1,8 +1,6 @@
 package starling
 
 import (
-	"encoding/json"
-	"strconv"
 	"strings"
 	"time"
 
@@ -160,7 +158,6 @@ type ErrorMessage struct {
 }
 
 type Error struct {
-	HTTPStatus    int
 	Code          string         `json:"error"`
 	Message       string         `json:"error_description"`
 	Success       bool           `json:"success"`
@@ -186,33 +183,5 @@ func (err Error) Error() string {
 		sb.WriteString("] ")
 	}
 
-	if err.HTTPStatus != 0 {
-		errorMessages := make([]string, len(err.ErrorMessages))
-		for i, e := range err.ErrorMessages {
-			errorMessages[i] = e.Message
-		}
-
-		sb.WriteString("(http status=")
-		sb.WriteString(strconv.Itoa(err.HTTPStatus))
-		sb.WriteString(")")
-	}
-
 	return sb.String()
-}
-
-func UnmarshalError(status int, body []byte) error {
-	if len(body) != 0 {
-		apiError := Error{}
-		if err := json.Unmarshal(body, &apiError); err == nil {
-			apiError.HTTPStatus = status
-		}
-
-		return apiError
-	}
-
-	return Error{
-		HTTPStatus: status,
-		Code:       "unknown",
-		Message:    "unknown",
-	}
 }

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -71,6 +71,9 @@ func NewExporter(exportType ExportType, opts Options) (Exporter, error) {
 }
 
 func All() []ExportType {
+	registryLock.RLock()
+	defer registryLock.RUnlock()
+
 	exportTypes := make([]ExportType, 0, len(registry))
 	for exportType := range registry {
 		exportTypes = append(exportTypes, exportType)

--- a/internal/util/sliceutil/sliceutil_test.go
+++ b/internal/util/sliceutil/sliceutil_test.go
@@ -10,35 +10,30 @@ import (
 func TestFilter(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name     string
+	filterFn := func(x int) bool { return x%2 == 0 }
+
+	tests := map[string]struct {
 		input    []int
 		expected []int
 	}{
-		{
-			name:     "filter even numbers",
+		"filter even numbers": {
 			input:    []int{1, 2, 3, 4, 5, 6},
 			expected: []int{2, 4, 6},
 		},
-		{
-			name:     "filter empty list",
+		"filter empty list": {
 			input:    []int{},
 			expected: []int{},
 		},
-		{
-			name:     "filter all false",
+		"filter all false": {
 			input:    []int{1, 3, 5},
 			expected: []int{},
 		},
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := func(x int) bool { return x%2 == 0 }
-
-			result := sliceutil.Filter(test.input, filter)
-
+			result := sliceutil.Filter(test.input, filterFn)
 			require.Equal(t, test.expected, result)
 		})
 	}

--- a/internal/util/testutil/test_http_server.go
+++ b/internal/util/testutil/test_http_server.go
@@ -6,8 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 type HTTPTestRoute struct {
@@ -41,7 +39,6 @@ func NewHTTPTestServer(t *testing.T, routes []HTTPTestRoute) *httptest.Server {
 	}
 
 	server := httptest.NewServer(router)
-
 	t.Cleanup(server.Close)
 
 	return server
@@ -50,12 +47,11 @@ func NewHTTPTestServer(t *testing.T, routes []HTTPTestRoute) *httptest.Server {
 func ServeJSONTestDataHandler(t *testing.T, statusCode int, filename string) http.HandlerFunc {
 	t.Helper()
 
+	data := LoadTestDataFile(t, filename)
+
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
-
-		data := LoadTestDataFile(t, filename)
-		_, err := w.Write(data)
-		assert.NoError(t, err, "failed to write test response")
+		_, _ = w.Write(data)
 	}
 }

--- a/internal/util/testutil/testutil.go
+++ b/internal/util/testutil/testutil.go
@@ -1,12 +1,13 @@
 package testutil
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,25 +21,45 @@ func LoadTestDataFile(t *testing.T, filename string) []byte {
 	require.NoError(t, err, "test data file %s must exist", filename)
 
 	b, err := os.ReadFile(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return b
 }
 
-// Validates that an HTTP request matches the expected method, headers, and query parameters.
-func AssertRequest(t *testing.T, r *http.Request, method string, expectedHeaders map[string]string, expectedQueryParams map[string]string) {
+func MarshalTestDataFile[T any](t *testing.T, filename string) *T {
 	t.Helper()
 
-	assert.Equal(t, method, r.Method, "HTTP method should match")
+	bytes := LoadTestDataFile(t, filename)
+
+	var result T
+	err := json.Unmarshal(bytes, &result)
+	require.NoError(t, err)
+
+	return &result
+}
+
+// Validates that an HTTP request matches the expected method, headers, and query parameters.
+func AssertRequest(t *testing.T, r *http.Request, method string, expectedHeaders http.Header, expectedQueryParams url.Values) {
+	t.Helper()
+
+	require.Equal(t, method, r.Method, "HTTP method should match")
 
 	for header, expected := range expectedHeaders {
-		actual := r.Header.Get(header)
-		assert.Equal(t, expected, actual, "header %s should match", header)
+		actual := r.Header.Values(header)
+		require.Equal(t, expected, actual, "header %s should match", header)
 	}
 
 	query := r.URL.Query()
 	for key, expected := range expectedQueryParams {
-		actual := query.Get(key)
-		assert.Equal(t, expected, actual, "query param %s should match", key)
+		actual := query[key]
+		require.Equal(t, expected, actual, "query param %s should match", key)
 	}
+}
+
+func MustParse[T any](t *testing.T, input string, fn func(string) (T, error)) T {
+	t.Helper()
+
+	result, err := fn(input)
+	require.NoError(t, err)
+	return result
 }


### PR DESCRIPTION
- Move request logging to `resty` response middleware.
- Use `resty.SetError` to automatically unmarshall API errors (and thus removing the need for `errorUnmarshallerFn`)
- Improve client API by using `url.Values` instead of `map[string]string`