### PR TITLE
Fix date range not converted to days from hours

### DIFF
--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -96,7 +96,9 @@ func Transactions(ctx context.Context, exportType ExportType, opts Options, form
 
 	maxDateRange := exporter.MaxDateRange()
 	if maxDateRange > 0 && opts.EndDate.Sub(opts.StartDate) > maxDateRange {
-		return fmt.Errorf("date range is too long, max is %d days", int(maxDateRange/time.Hour*24))
+		hours := maxDateRange.Hours()
+		days := hours / 24
+		return fmt.Errorf("date range is too long, max is %d days", int(days))
 	}
 
 	ctx = zerolog.Ctx(ctx).With().

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -115,7 +115,7 @@ func TestTransactions(t *testing.T) {
 			AuthToken: "token",
 		}, formatter)
 
-		require.ErrorContains(t, err, "date range is too long")
+		require.ErrorContains(t, err, "date range is too long, max is 1 days")
 	})
 
 	tests := []struct {


### PR DESCRIPTION
When the start time is too far in the past, we return an error for some APIs (because they won't allow you to export). The error we displayed was showing an incorrect time in hours, instead of in days.