### PR TITLE
Refactor cli code to improve logging, parsing, output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,20 +30,6 @@ var (
 )
 
 func init() {
-	rootCmd.SilenceUsage = true
-	rootCmd.SilenceErrors = true
-	rootCmd.CompletionOptions.DisableDefaultCmd = true
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
-
-	for _, exportType := range export.All() {
-		cmd := newExportCommand(exportType)
-		exportCmd.AddCommand(cmd)
-	}
-
-	rootCmd.AddCommand(exportCmd)
-}
-
-func init() {
 	export.Register(starlingexporter.ExportTypeStarling, func(opts export.Options) (export.Exporter, error) {
 		client := &http.Client{
 			Timeout: opts.Timeout,
@@ -61,6 +47,17 @@ func init() {
 		api := monzo.New(client, monzo.WithAuthToken(opts.BearerAuthToken()))
 		return monzoexporter.New(api)
 	})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
+
+	for _, exportType := range export.All() {
+		cmd := newExportCommand(exportType)
+		exportCmd.AddCommand(cmd)
+	}
+
+	rootCmd.AddCommand(exportCmd)
 }
 
 func Main(ctx context.Context, args []string, output io.Writer, errOutput io.Writer) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/HallyG/fingrab/internal/export"
+	"github.com/HallyG/fingrab/internal/log"
 	"github.com/HallyG/fingrab/internal/monzo"
 	monzoexporter "github.com/HallyG/fingrab/internal/monzo/exporter"
 	"github.com/HallyG/fingrab/internal/starling"
 	starlingexporter "github.com/HallyG/fingrab/internal/starling/exporter"
-	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
 
@@ -47,6 +47,7 @@ func init() {
 		api := monzo.New(client, monzo.WithAuthToken(opts.BearerAuthToken()))
 		return monzoexporter.New(api)
 	})
+
 	rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
@@ -65,33 +66,31 @@ func Main(ctx context.Context, args []string, output io.Writer, errOutput io.Wri
 	rootCmd.SetErr(errOutput)
 	rootCmd.SetArgs(args[1:])
 
-	return rootCmd.ExecuteContext(ctx)
+	verbose, _ := rootCmd.Flags().GetBool("verbose")
+	logger := log.New(
+		log.WithWriter(errOutput),
+		log.WithVerbose(verbose),
+		log.WithAttrs(
+			slog.String("build.version", BuildVersion),
+			slog.String("build.sha", BuildShortSHA),
+		),
+	)
+	return rootCmd.ExecuteContext(log.WithContext(ctx, logger))
 }
 
 func setupLogger(cmd *cobra.Command, _ []string) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	logger := log.New(
+		log.WithWriter(cmd.ErrOrStderr()),
+		log.WithVerbose(verbose),
+		log.WithJSONFormat(false),
+		log.WithAttrs(
+			slog.String("build.version", BuildVersion),
+			slog.String("build.sha", BuildShortSHA),
+		),
+	)
 
-	writer := zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
-		w.Out = cmd.ErrOrStderr()
-		w.TimeFormat = time.RFC3339
-		w.PartsExclude = []string{"time", "level"}
-	})
-
-	logger := zerolog.New(writer).
-		With().
-		Timestamp().
-		Str("build.version", BuildShortSHA).
-		Str("build.sha", BuildShortSHA).
-		Logger()
-
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-
-	if verbose {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	}
-
-	ctx := logger.WithContext(cmd.Context())
+	ctx := log.WithContext(cmd.Context(), logger)
 	cmd.SetContext(ctx)
-
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,7 +83,7 @@ func setupLogger(cmd *cobra.Command, _ []string) error {
 	logger := log.New(
 		log.WithWriter(cmd.ErrOrStderr()),
 		log.WithVerbose(verbose),
-		log.WithJSONFormat(false),
+		log.WithTextHandler(true),
 		log.WithAttrs(
 			slog.String("build.version", BuildVersion),
 			slog.String("build.sha", BuildShortSHA),

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Rhymond/go-money v1.0.15
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/google/uuid v1.6.0
-	github.com/rs/zerolog v1.34.0
+	github.com/lmittmann/tint v1.1.2
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	resty.dev/v3 v3.0.0-beta.3
@@ -199,7 +199,7 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
-	golang.org/x/sync v0.13.0 // indirect
+	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/tools v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,7 +138,6 @@ github.com/ckaznocha/intrange v0.3.1 h1:j1onQyXvHUsPWujDH6WIjhyH26gkRt/txNlV7Lsp
 github.com/ckaznocha/intrange v0.3.1/go.mod h1:QVepyz1AkUoFQkpEqksSYpNpUo3c5W7nWh/s6SHIJJk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/curioswitch/go-reassign v0.3.0 h1:dh3kpQHuADL3cobV/sSGETA8DOv457dwl+fbBAhrQPs=
 github.com/curioswitch/go-reassign v0.3.0/go.mod h1:nApPCCTtqLJN/s8HfItCcKV0jIPwluBOvZP+dsJGA88=
@@ -220,7 +219,6 @@ github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUW
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -389,6 +387,8 @@ github.com/ldez/usetesting v0.4.3 h1:pJpN0x3fMupdTf/IapYjnkhiY1nSTN+pox1/GyBRw3k
 github.com/ldez/usetesting v0.4.3/go.mod h1:eEs46T3PpQ+9RgN9VjpY6qWdiw2/QmfiDeWmdZdrjIQ=
 github.com/leonklingele/grouper v1.1.2 h1:o1ARBDLOmmasUaNDesWqWCIFH3u7hoFlM84YrjT3mIY=
 github.com/leonklingele/grouper v1.1.2/go.mod h1:6D0M/HVkhs2yRKRFZUoGjeDy7EZTfFBE9gl4kjmIGkA=
+github.com/lmittmann/tint v1.1.2 h1:2CQzrL6rslrsyjqLDwD11bZ5OpLBPU+g3G/r5LSfS8w=
+github.com/lmittmann/tint v1.1.2/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/macabu/inamedparam v0.2.0 h1:VyPYpOc10nkhI2qeNUdh3Zket4fcZjEWe35poddBCpE=
@@ -405,11 +405,8 @@ github.com/matoous/godox v1.1.0 h1:W5mqwbyWrwZv6OQ5Z1a/DHGMOvXYCBP3+Ht7KMoJhq4=
 github.com/matoous/godox v1.1.0/go.mod h1:jgE/3fUXiTurkdHOLT5WEkThTSuE7yxHv5iWPa80afs=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
 github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -509,9 +506,6 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
-github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
-github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.4.1 h1:eWC8eUMNZ/wM/PWuZBv7JxxqT5fiIKSIyTvjb7Elr+g=
 github.com/ryancurrah/gomodguard v1.4.1/go.mod h1:qnMJwV1hX9m+YJseXEBhd2s90+1Xn6x9dLz11ualI1I=
@@ -762,8 +756,8 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
-golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -810,7 +804,6 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -105,7 +105,7 @@ func Transactions(ctx context.Context, exportType ExportType, opts Options, form
 		return fmt.Errorf("date range is too long, max is %d days", int(days))
 	}
 
-	logger := log.FromContext(ctx).With(slog.String("exporter.type", string(exportType)))
+	logger := log.FromContext(ctx).With(slog.String("bank", string(exportType)))
 	ctx = log.WithContext(ctx, logger)
 
 	transactions, err := exporter.ExportTransactions(ctx, opts)

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -3,6 +3,7 @@ package export
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync"
@@ -10,8 +11,8 @@ import (
 
 	"github.com/HallyG/fingrab/internal/domain"
 	"github.com/HallyG/fingrab/internal/format"
+	"github.com/HallyG/fingrab/internal/log"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"github.com/rs/zerolog"
 )
 
 type ExportType string
@@ -104,10 +105,8 @@ func Transactions(ctx context.Context, exportType ExportType, opts Options, form
 		return fmt.Errorf("date range is too long, max is %d days", int(days))
 	}
 
-	ctx = zerolog.Ctx(ctx).With().
-		Str("exporter.type", string(exportType)).
-		Logger().
-		WithContext(ctx)
+	logger := log.FromContext(ctx).With(slog.String("exporter.type", string(exportType)))
+	ctx = log.WithContext(ctx, logger)
 
 	transactions, err := exporter.ExportTransactions(ctx, opts)
 	if err != nil {

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -3,15 +3,12 @@ package export
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"slices"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/HallyG/fingrab/internal/domain"
-	"github.com/HallyG/fingrab/internal/format"
-	"github.com/HallyG/fingrab/internal/log"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
@@ -30,7 +27,6 @@ type Options struct {
 	StartDate time.Time
 	AuthToken string
 	Timeout   time.Duration
-	Format    format.FormatType
 }
 
 func (o Options) Validate(ctx context.Context) error {
@@ -88,44 +84,27 @@ func All() []ExportType {
 	return exportTypes
 }
 
-func Transactions(ctx context.Context, exportType ExportType, opts Options, formatter format.Formatter) error {
+func Transactions(ctx context.Context, exportType ExportType, opts Options) ([]*domain.Transaction, error) {
 	if err := opts.Validate(ctx); err != nil {
-		return fmt.Errorf("invalid options: %w", err)
+		return nil, fmt.Errorf("invalid options: %w", err)
 	}
 
 	exporter, err := NewExporter(exportType, opts)
 	if err != nil {
-		return fmt.Errorf("failed to create %s exporter: %w", exportType, err)
+		return nil, fmt.Errorf("failed to create %s exporter: %w", exportType, err)
 	}
 
 	maxDateRange := exporter.MaxDateRange()
 	if maxDateRange > 0 && opts.EndDate.Sub(opts.StartDate) > maxDateRange {
 		hours := maxDateRange.Hours()
 		days := hours / 24
-		return fmt.Errorf("date range is too long, max is %d days", int(days))
+		return nil, fmt.Errorf("date range is too long, max is %d days", int(days))
 	}
-
-	logger := log.FromContext(ctx).With(slog.String("bank", string(exportType)))
-	ctx = log.WithContext(ctx, logger)
 
 	transactions, err := exporter.ExportTransactions(ctx, opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if err := formatter.WriteHeader(); err != nil {
-		return fmt.Errorf("failed to write header: %w", err)
-	}
-
-	for _, t := range transactions {
-		if err := formatter.WriteTransaction(t); err != nil {
-			return fmt.Errorf("failed to write transaction: %w", err)
-		}
-	}
-
-	if err := formatter.Flush(); err != nil {
-		return fmt.Errorf("failed to flush formatter: %w", err)
-	}
-
-	return nil
+	return transactions, nil
 }

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -1,16 +1,13 @@
 package export_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"testing"
 	"time"
 
 	"github.com/HallyG/fingrab/internal/domain"
 	"github.com/HallyG/fingrab/internal/export"
-	"github.com/HallyG/fingrab/internal/format"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,143 +42,62 @@ func TestTransactions(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		buffer := bytes.NewBuffer(nil)
-		formatter := &StubFormatter{w: buffer}
-
-		err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
-			Format:    format.FormatTypeMoneyDance,
+		transactions, err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
 			EndDate:   time.Now(),
 			StartDate: time.Now(),
 			AuthToken: "token",
-		}, formatter)
+		})
 
+		require.Len(t, transactions, 1)
 		require.NoError(t, err)
 	})
 
 	t.Run("invalid opts", func(t *testing.T) {
 		t.Parallel()
 
-		buffer := bytes.NewBuffer(nil)
-		formatter := &StubFormatter{w: buffer}
-
-		err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
-			Format:    format.FormatTypeMoneyDance,
+		transcations, err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
 			StartDate: time.Now(),
 			AuthToken: "token",
-		}, formatter)
+		})
 
+		require.Nil(t, transcations)
 		require.ErrorContains(t, err, "end time is required")
 	})
 
 	t.Run("invalid exporter", func(t *testing.T) {
 		t.Parallel()
 
-		buffer := bytes.NewBuffer(nil)
-		formatter := &StubFormatter{w: buffer}
-
-		err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
-			Format:    format.FormatTypeMoneyDance,
+		transcations, err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
 			EndDate:   time.Now(),
 			StartDate: time.Now(),
 			AuthToken: "12345",
-		}, formatter)
+		})
 
+		require.Nil(t, transcations)
 		require.ErrorContains(t, err, "failed to create stubtype exporter")
 	})
 
 	t.Run("date range too long", func(t *testing.T) {
 		t.Parallel()
 
-		buffer := bytes.NewBuffer(nil)
-		formatter := &StubFormatter{w: buffer}
-
-		err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
-			Format:    format.FormatTypeMoneyDance,
+		transactions, err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
 			StartDate: time.Now().Add(-48 * time.Hour),
 			EndDate:   time.Now(),
 			AuthToken: "token",
-		}, formatter)
+		})
 
 		require.ErrorContains(t, err, "date range is too long, max is 1 days")
-	})
-
-	tests := []struct {
-		name           string
-		expectedMsg    string
-		headerErr      error
-		transactionErr error
-		flushErr       error
-	}{
-		{
-			name:        "formatter write header error",
-			expectedMsg: "header error",
-			headerErr:   errors.New("header error"),
-		},
-		{
-			name:           "formatter write transaction error",
-			expectedMsg:    "transaction error",
-			transactionErr: errors.New("transaction error"),
-		},
-		{
-			name:        "formatter flush error",
-			expectedMsg: "flush error",
-			flushErr:    errors.New("flush error"),
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			buffer := bytes.NewBuffer(nil)
-			formatter := &StubFormatter{w: buffer}
-			formatter.headerErr = test.headerErr
-			formatter.transactionErr = test.transactionErr
-			formatter.flushErr = test.flushErr
-
-			err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
-				Format:    format.FormatTypeMoneyDance,
-				EndDate:   time.Now(),
-				StartDate: time.Now(),
-				AuthToken: "token",
-			}, formatter)
-
-			require.ErrorContains(t, err, test.expectedMsg)
-		})
-	}
-
-	t.Run("success", func(t *testing.T) {
-		t.Parallel()
-
-		buffer := bytes.NewBuffer(nil)
-		formatter := &StubFormatter{w: buffer}
-
-		err := export.Transactions(t.Context(), ExportTypeStub, export.Options{
-			Format:    format.FormatTypeMoneyDance,
-			EndDate:   time.Now(),
-			StartDate: time.Now(),
-			AuthToken: "token",
-		}, formatter)
-
-		require.NoError(t, err)
-		require.Contains(t, "header content\ntransaction content\n", buffer.String())
+		require.Nil(t, transactions)
 	})
 }
 
 const ExportTypeStub export.ExportType = "stubtype"
 
 var _ export.Exporter = (*StubExporter)(nil)
-var _ format.Formatter = (*StubFormatter)(nil)
 
 type StubExporter struct {
 	transactions []*domain.Transaction
 	err          error
-}
-
-type StubFormatter struct {
-	w              io.Writer
-	headerErr      error
-	transactionErr error
-	flushErr       error
 }
 
 func (s *StubExporter) Type() export.ExportType {
@@ -194,28 +110,4 @@ func (s *StubExporter) MaxDateRange() time.Duration {
 
 func (s *StubExporter) ExportTransactions(ctx context.Context, opts export.Options) ([]*domain.Transaction, error) {
 	return s.transactions, s.err
-}
-
-func (s *StubFormatter) WriteHeader() error {
-	if s.headerErr != nil {
-		return s.headerErr
-	}
-
-	_, err := s.w.Write([]byte("header content\n"))
-
-	return err
-}
-
-func (s *StubFormatter) WriteTransaction(transaction *domain.Transaction) error {
-	if s.transactionErr != nil {
-		return s.transactionErr
-	}
-
-	_, err := s.w.Write([]byte("transaction content\n"))
-
-	return err
-}
-
-func (s *StubFormatter) Flush() error {
-	return s.flushErr
 }

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,6 +1,9 @@
 package format_test
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -8,6 +11,39 @@ import (
 	"github.com/HallyG/fingrab/internal/format"
 	"github.com/stretchr/testify/require"
 )
+
+var _ format.Formatter = (*StubFormatter)(nil)
+
+type StubFormatter struct {
+	w              io.Writer
+	headerErr      error
+	transactionErr error
+	flushErr       error
+}
+
+func (s *StubFormatter) WriteHeader() error {
+	if s.headerErr != nil {
+		return s.headerErr
+	}
+
+	_, err := s.w.Write([]byte("header content\n"))
+
+	return err
+}
+
+func (s *StubFormatter) WriteTransaction(transaction *domain.Transaction) error {
+	if s.transactionErr != nil {
+		return s.transactionErr
+	}
+
+	_, err := s.w.Write([]byte("transaction content\n"))
+
+	return err
+}
+
+func (s *StubFormatter) Flush() error {
+	return s.flushErr
+}
 
 func TestAll(t *testing.T) {
 	t.Parallel()
@@ -33,43 +69,76 @@ func TestNewFormatter(t *testing.T) {
 	})
 }
 
-func writeTestTransactions(t *testing.T, now time.Time, formatter format.Formatter) {
+func TestWriteAll(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		expectedMsg    string
+		headerErr      error
+		transactionErr error
+		flushErr       error
+	}{
+		{
+			name:        "formatter write header error",
+			expectedMsg: "header error",
+			headerErr:   errors.New("header error"),
+		},
+		{
+			name:           "formatter write transaction error",
+			expectedMsg:    "transaction error",
+			transactionErr: errors.New("transaction error"),
+		},
+		{
+			name:        "formatter flush error",
+			expectedMsg: "flush error",
+			flushErr:    errors.New("flush error"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			buffer := bytes.NewBuffer(nil)
+			formatter := &StubFormatter{w: buffer}
+			formatter.headerErr = test.headerErr
+			formatter.transactionErr = test.transactionErr
+			formatter.flushErr = test.flushErr
+
+			err := format.WriteCollection(formatter, testTransactions(t, time.Now()))
+			require.ErrorContains(t, err, test.expectedMsg)
+		})
+	}
+}
+
+func testTransactions(t *testing.T, now time.Time) []*domain.Transaction {
 	t.Helper()
-
-	err := formatter.WriteHeader()
-	require.NoError(t, err)
-
-	err = formatter.WriteTransaction(&domain.Transaction{
-		CreatedAt: now,
-		Reference: "Test Transaction",
-		Category:  "Test Category",
-		Amount:    domain.Money{MinorUnit: 12345, Currency: "GBP"},
-		Notes:     "Test Notes",
-		IsDeposit: true,
-	})
-	require.NoError(t, err)
-
-	err = formatter.WriteTransaction(&domain.Transaction{
-		CreatedAt: now,
-		Reference: "Another Test Transaction",
-		Category:  "Another Test Category",
-		Amount:    domain.Money{MinorUnit: -12345, Currency: "GBP"},
-		Notes:     "More notes",
-	})
-	require.NoError(t, err)
 
 	time, err := time.Parse(time.RFC3339, "2025-05-04T23:16:52.392Z") // close to midnight boundary so we can test timezone changes
 	require.NoError(t, err)
 
-	err = formatter.WriteTransaction(&domain.Transaction{
-		CreatedAt: time,
-		Reference: "Transaction With Date Affected By Timezone",
-		Category:  "Test Category",
-		Amount:    domain.Money{MinorUnit: -100, Currency: "GBP"},
-		Notes:     "Test Notes",
-	})
-	require.NoError(t, err)
-
-	err = formatter.Flush()
-	require.NoError(t, err)
+	return []*domain.Transaction{
+		{
+			CreatedAt: now,
+			Reference: "Test Transaction",
+			Category:  "Test Category",
+			Amount:    domain.Money{MinorUnit: 12345, Currency: "GBP"},
+			Notes:     "Test Notes",
+			IsDeposit: true,
+		},
+		{
+			CreatedAt: now,
+			Reference: "Another Test Transaction",
+			Category:  "Another Test Category",
+			Amount:    domain.Money{MinorUnit: -12345, Currency: "GBP"},
+			Notes:     "More notes",
+		},
+		{
+			CreatedAt: time,
+			Reference: "Transaction With Date Affected By Timezone",
+			Category:  "Test Category",
+			Amount:    domain.Money{MinorUnit: -100, Currency: "GBP"},
+			Notes:     "Test Notes",
+		},
+	}
 }

--- a/internal/format/moneydance_test.go
+++ b/internal/format/moneydance_test.go
@@ -22,7 +22,8 @@ func TestMoneyDanceFormatter(t *testing.T) {
 		formatter, err := format.NewFormatter(format.FormatTypeMoneyDance, buffer)
 		require.NoError(t, err)
 
-		writeTestTransactions(t, now, formatter)
+		err = format.WriteCollection(formatter, testTransactions(t, now))
+		require.NoError(t, err)
 
 		expected := `check number,date,description,category,amount,memo
 Dep,2025-04-16,Test Transaction,Test Category,123.45,Test Notes

--- a/internal/format/ynab_test.go
+++ b/internal/format/ynab_test.go
@@ -22,7 +22,8 @@ func TestYNABFormatter(t *testing.T) {
 		formatter, err := format.NewFormatter(format.FormatTypeYNAB, buffer)
 		require.NoError(t, err)
 
-		writeTestTransactions(t, now, formatter)
+		err = format.WriteCollection(formatter, testTransactions(t, now))
+		require.NoError(t, err)
 
 		expected := `Date,Payee,Memo,Amount
 04/16/2025,Test Transaction,Test Notes,123.45

--- a/internal/log/context.go
+++ b/internal/log/context.go
@@ -1,0 +1,24 @@
+package log
+
+import (
+	"context"
+	"log/slog"
+)
+
+type (
+	logCtxKey struct{}
+)
+
+func WithContext(ctx context.Context, logger *slog.Logger) context.Context {
+	ctx = context.WithValue(ctx, logCtxKey{}, logger)
+	return context.WithValue(ctx, logCtxKey{}, logger)
+}
+
+func FromContext(ctx context.Context) *slog.Logger {
+	logger, ok := ctx.Value(logCtxKey{}).(*slog.Logger)
+	if ok && logger != nil {
+		return logger
+	}
+
+	return New(WithWriter(nil))
+}

--- a/internal/log/context_test.go
+++ b/internal/log/context_test.go
@@ -1,0 +1,49 @@
+package log_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/HallyG/fingrab/internal/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContext(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		setupCtx    func(t *testing.T) (context.Context, *slog.Logger)
+		expectEqual bool
+	}{
+		"logger in context": {
+			setupCtx: func(t *testing.T) (context.Context, *slog.Logger) {
+				t.Helper()
+
+				logger := slog.New(slog.DiscardHandler)
+				ctx := log.WithContext(t.Context(), logger)
+				return ctx, logger
+			},
+		},
+		"no logger in context": {
+			setupCtx: func(t *testing.T) (context.Context, *slog.Logger) {
+				t.Helper()
+
+				logger := log.New(log.WithWriter(nil))
+				return t.Context(), logger
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, originalLogger := test.setupCtx(t)
+			logger := log.FromContext(ctx)
+
+			require.NotNil(t, originalLogger)
+			require.NotNil(t, logger)
+			require.Equal(t, originalLogger, logger)
+		})
+	}
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,112 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+)
+
+type params struct {
+	verbose    bool
+	jsonFormat bool
+	attrs      []slog.Attr
+	writer     io.Writer
+}
+
+type Option func(params *params)
+
+// WithVerbose enables verbose logging (sets log level to Debug).
+func WithVerbose(verbose bool) Option {
+	return func(params *params) {
+		params.verbose = verbose
+	}
+}
+
+// WithJSONFormat enables JSON formatting for logs
+func WithJSONFormat(json bool) Option {
+	return func(params *params) {
+		params.jsonFormat = json
+	}
+}
+
+// WithAttrs adds custom attributes to all log entries.
+// Attributes are key-value pairs that provide additional context.
+func WithAttrs(attrs ...slog.Attr) Option {
+	return func(params *params) {
+		params.attrs = append(params.attrs, attrs...)
+	}
+}
+
+// WithWriter sets the output writer for logs.
+// If w is nil, io.Discard is used
+func WithWriter(w io.Writer) Option {
+	return func(params *params) {
+		params.writer = w
+	}
+}
+
+// New creates a new slog.Logger.
+// By default, logs are formatted as text, written to io.Discard, and use Info level.
+//
+// Example:
+//
+//	logger, err := log.New(
+//	    log.WithWriter(os.Stdout),
+//	    log.WithJSONFormat(true),
+//	    log.WithVerbose(true),
+//	    log.WithAttrs(slog.String("service", "api")),
+//	)
+func New(opts ...Option) *slog.Logger {
+	var params params
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+
+		opt(&params)
+	}
+
+	if params.writer == nil {
+		return slog.New(slog.DiscardHandler)
+	}
+
+	level := slog.LevelInfo
+	if params.verbose {
+		level = slog.LevelDebug
+	}
+
+	handlerOpts := &slog.HandlerOptions{
+		Level:       level,
+		AddSource:   true,
+		ReplaceAttr: replaceSourceAttr,
+	}
+
+	var handler slog.Handler
+	if params.jsonFormat {
+		handler = slog.NewJSONHandler(params.writer, handlerOpts)
+	} else {
+		handler = slog.NewTextHandler(params.writer, handlerOpts)
+	}
+
+	attrs := []slog.Attr{}
+	attrs = append(attrs, params.attrs...)
+	return slog.New(handler.WithAttrs(attrs))
+}
+
+func replaceSourceAttr(groups []string, a slog.Attr) slog.Attr {
+	if a.Key != slog.SourceKey {
+		return a
+	}
+
+	source, ok := a.Value.Any().(*slog.Source)
+	if !ok {
+		return a
+	}
+
+	fileAndLine := fmt.Sprintf("%s:%d", filepath.Base(source.File), source.Line)
+	return slog.Attr{
+		Key:   slog.SourceKey,
+		Value: slog.StringValue(fileAndLine),
+	}
+}

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -49,8 +49,12 @@ func TestNew(t *testing.T) {
 			expectedVerbose: true,
 		},
 		"json format": {
-			opts:         []log.Option{log.WithJSONFormat(true)},
+			opts:         []log.Option{log.WithJSONHandler()},
 			expectedJSON: true,
+		},
+		"text format": {
+			opts:         []log.Option{log.WithTextHandler(false)},
+			expectedJSON: false,
 		},
 		"populates source attribute": {
 			expectedAttrs: []string{"source=log_test.go"},
@@ -105,10 +109,8 @@ func assertIsJSONHandler(t *testing.T, logger *slog.Logger, expectedJSON bool) {
 	switch handler.(type) {
 	case *slog.JSONHandler:
 		isJSONHandler = true
-	case *slog.TextHandler:
-		isJSONHandler = false
 	default:
-		t.Fatalf("unexpected slog handler type: %T", logger.Handler())
+		isJSONHandler = false
 	}
 
 	require.Equal(t, expectedJSON, isJSONHandler)

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,115 @@
+package log_test
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/HallyG/fingrab/internal/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero opts", func(t *testing.T) {
+		t.Parallel()
+
+		logger := log.New()
+		require.NotNil(t, logger)
+	})
+
+	t.Run("empty opts", func(t *testing.T) {
+		t.Parallel()
+
+		opts := make([]log.Option, 0)
+		logger := log.New(opts...)
+		require.NotNil(t, logger)
+
+		require.Equal(t, slog.DiscardHandler, logger.Handler())
+	})
+
+	t.Run("nil opts", func(t *testing.T) {
+		t.Parallel()
+
+		logger := log.New(nil)
+		require.NotNil(t, logger)
+
+		require.Equal(t, slog.DiscardHandler, logger.Handler())
+	})
+
+	tests := map[string]struct {
+		opts            []log.Option
+		expectedAttrs   []string
+		expectedJSON    bool
+		expectedVerbose bool
+	}{
+		"verbose": {
+			opts:            []log.Option{log.WithVerbose(true)},
+			expectedVerbose: true,
+		},
+		"json format": {
+			opts:         []log.Option{log.WithJSONFormat(true)},
+			expectedJSON: true,
+		},
+		"populates source attribute": {
+			expectedAttrs: []string{"source=log_test.go"},
+		},
+		"custom attributes": {
+			opts:          []log.Option{log.WithAttrs(slog.String("very", "nice"))},
+			expectedAttrs: []string{"very=nice"},
+		},
+		"overwritten source attribute": {
+			opts:          []log.Option{log.WithAttrs(slog.String("source", "something else"))},
+			expectedAttrs: []string{`source="something else"`},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			test.opts = append(test.opts, log.WithWriter(&buf))
+			logger := log.New(test.opts...)
+
+			logger.Info("test message")
+			output := buf.String()
+			for _, attr := range test.expectedAttrs {
+				require.Contains(t, output, attr)
+			}
+
+			assertIsVerbose(t, logger, &buf, test.expectedVerbose)
+			assertIsJSONHandler(t, logger, test.expectedJSON)
+		})
+	}
+}
+
+func assertIsVerbose(t *testing.T, logger *slog.Logger, buf *bytes.Buffer, expectedVerbose bool) {
+	t.Helper()
+
+	logger.Debug("debug message")
+	output := buf.String()
+
+	if expectedVerbose {
+		require.Contains(t, output, "debug message")
+	} else {
+		require.NotContains(t, output, "debug message")
+	}
+}
+
+func assertIsJSONHandler(t *testing.T, logger *slog.Logger, expectedJSON bool) {
+	t.Helper()
+
+	handler := logger.Handler()
+	isJSONHandler := false
+	switch handler.(type) {
+	case *slog.JSONHandler:
+		isJSONHandler = true
+	case *slog.TextHandler:
+		isJSONHandler = false
+	default:
+		t.Fatalf("unexpected slog handler type: %T", logger.Handler())
+	}
+
+	require.Equal(t, expectedJSON, isJSONHandler)
+}

--- a/internal/monzo/exporter/exporter.go
+++ b/internal/monzo/exporter/exporter.go
@@ -52,7 +52,6 @@ func (m *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 	}
 
 	log.FromContext(ctx).InfoContext(ctx, "starting export of transactions",
-		slog.String("bank", Monzo),
 		slog.String("export.start", opts.StartDate.Format(monzoTimeFormat)),
 		slog.String("export.end", opts.EndDate.Format(monzoTimeFormat)),
 	)
@@ -73,7 +72,6 @@ func (m *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 	}
 
 	log.FromContext(ctx).InfoContext(ctx, "successfully exported transactions",
-		slog.String("bank", Monzo),
 		slog.Int("transaction.count", len(transactions)),
 	)
 
@@ -93,7 +91,6 @@ func (m *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 // Enrich Transaction Descriptions with Pot Name.
 func (m *TransactionExporter) enrichTransactionDescriptions(ctx context.Context, accountID monzo.AccountID, transactions []*monzo.Transaction) error {
 	log.FromContext(ctx).DebugContext(ctx, "enriching transaction descriptions",
-		slog.String("bank", Monzo),
 		slog.String("account.id", string(accountID)),
 	)
 
@@ -103,7 +100,6 @@ func (m *TransactionExporter) enrichTransactionDescriptions(ctx context.Context,
 	}
 
 	log.FromContext(ctx).DebugContext(ctx, "fetched pots",
-		slog.String("bank", Monzo),
 		slog.String("account.id", string(accountID)),
 		slog.Int("pots.total", len(pots)),
 	)
@@ -143,12 +139,10 @@ func (m *TransactionExporter) fetchAccount(ctx context.Context, accountID string
 	}
 
 	log.FromContext(ctx).InfoContext(ctx, "found accounts",
-		slog.String("bank", Monzo),
 		slog.Int("account.total", len(accountIDs)),
 	)
 
 	log.FromContext(ctx).InfoContext(ctx, "selected account",
-		slog.String("bank", Monzo),
 		slog.String("account.id", string(selectedAccount.ID)),
 	)
 
@@ -163,7 +157,6 @@ func (m *TransactionExporter) fetchTransactions(ctx context.Context, accountID m
 	limit := monzoTransactionBatch
 
 	log.FromContext(ctx).InfoContext(ctx, "fetching transactions",
-		slog.String("bank", Monzo),
 		slog.String("account.id", string(accountID)),
 		slog.String("start", startDate.Format(monzoTimeFormat)),
 		slog.String("end", endDate.Format(monzoTimeFormat)),
@@ -220,7 +213,6 @@ func (m *TransactionExporter) fetchTransactions(ctx context.Context, accountID m
 	}
 
 	log.FromContext(ctx).InfoContext(ctx, "fetched transactions",
-		slog.String("bank", Monzo),
 		slog.String("account.id", string(accountID)),
 		slog.Int("transaction.total", len(transactions)),
 	)

--- a/internal/monzo/exporter/exporter.go
+++ b/internal/monzo/exporter/exporter.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/HallyG/fingrab/internal/domain"
 	"github.com/HallyG/fingrab/internal/export"
+	"github.com/HallyG/fingrab/internal/log"
 	"github.com/HallyG/fingrab/internal/monzo"
 	"github.com/HallyG/fingrab/internal/util/sliceutil"
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -50,11 +51,11 @@ func (m *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 		return nil, fmt.Errorf("invalid opts: %w", err)
 	}
 
-	zerolog.Ctx(ctx).Info().
-		Str("bank", Monzo).
-		Str("export.start", opts.StartDate.Format(monzoTimeFormat)).
-		Str("export.end", opts.EndDate.Format(monzoTimeFormat)).
-		Msg("starting export of Monzo transactions")
+	log.FromContext(ctx).InfoContext(ctx, "starting export of transactions",
+		slog.String("bank", Monzo),
+		slog.String("export.start", opts.StartDate.Format(monzoTimeFormat)),
+		slog.String("export.end", opts.EndDate.Format(monzoTimeFormat)),
+	)
 
 	account, err := m.fetchAccount(ctx, opts.AccountID)
 	if err != nil {
@@ -71,10 +72,10 @@ func (m *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 		return nil, err
 	}
 
-	zerolog.Ctx(ctx).Info().
-		Str("bank", Monzo).
-		Int("transaction.count", len(transactions)).
-		Msg("successfully exported Monzo transactions")
+	log.FromContext(ctx).InfoContext(ctx, "successfully exported transactions",
+		slog.String("bank", Monzo),
+		slog.Int("transaction.count", len(transactions)),
+	)
 
 	return sliceutil.Map(transactions, func(txn *monzo.Transaction) *domain.Transaction {
 		return &domain.Transaction{
@@ -91,23 +92,21 @@ func (m *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 
 // Enrich Transaction Descriptions with Pot Name.
 func (m *TransactionExporter) enrichTransactionDescriptions(ctx context.Context, accountID monzo.AccountID, transactions []*monzo.Transaction) error {
-	zerolog.Ctx(ctx).Debug().
-		Ctx(ctx).
-		Str("bank", Monzo).
-		Str("account.id", string(accountID)).
-		Msg("enriching transaction descriptions")
+	log.FromContext(ctx).DebugContext(ctx, "enriching transaction descriptions",
+		slog.String("bank", Monzo),
+		slog.String("account.id", string(accountID)),
+	)
 
 	pots, err := m.api.FetchPots(ctx, accountID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch pots while enriching transactions: %w", err)
 	}
 
-	zerolog.Ctx(ctx).Debug().
-		Ctx(ctx).
-		Str("bank", Monzo).
-		Str("account.id", string(accountID)).
-		Int("pots.total", len(pots)).
-		Msg("fetched pots")
+	log.FromContext(ctx).DebugContext(ctx, "fetched pots",
+		slog.String("bank", Monzo),
+		slog.String("account.id", string(accountID)),
+		slog.Int("pots.total", len(pots)),
+	)
 
 	potMap := make(map[string]string)
 	for _, pot := range pots {
@@ -133,32 +132,25 @@ func (m *TransactionExporter) fetchAccount(ctx context.Context, accountID string
 		return nil, errors.New("no accounts found, exiting")
 	}
 
-	accountsArr := zerolog.Arr()
 	selectedAccount := accounts[0]
-
 	accountIDs := make([]monzo.AccountID, 0)
-
 	for _, account := range accounts {
 		if accountID == string(account.ID) {
 			selectedAccount = account
 		}
 
 		accountIDs = append(accountIDs, account.ID)
-		accountsArr.Str(string(account.ID))
 	}
 
-	zerolog.Ctx(ctx).Debug().
-		Ctx(ctx).
-		Str("bank", Monzo).
-		Int("account.total", len(accountIDs)).
-		Array("account.all", accountsArr).
-		Msg("found Monzo accounts")
+	log.FromContext(ctx).InfoContext(ctx, "found accounts",
+		slog.String("bank", Monzo),
+		slog.Int("account.total", len(accountIDs)),
+	)
 
-	zerolog.Ctx(ctx).Info().
-		Ctx(ctx).
-		Str("bank", Monzo).
-		Str("account.id", string(selectedAccount.ID)).
-		Msg("selected Monzo account")
+	log.FromContext(ctx).InfoContext(ctx, "selected account",
+		slog.String("bank", Monzo),
+		slog.String("account.id", string(selectedAccount.ID)),
+	)
 
 	return selectedAccount, nil
 }
@@ -170,14 +162,13 @@ func (m *TransactionExporter) fetchTransactions(ctx context.Context, accountID m
 	endDateExclusive := endDate.AddDate(0, 0, 1)
 	limit := monzoTransactionBatch
 
-	zerolog.Ctx(ctx).Debug().
-		Ctx(ctx).
-		Str("bank", Monzo).
-		Str("account.id", string(accountID)).
-		Time("start", startDate).
-		Time("end", endDate).
-		Int("limit", limit).
-		Msg("fetching Monzo transactions")
+	log.FromContext(ctx).InfoContext(ctx, "fetching transactions",
+		slog.String("bank", Monzo),
+		slog.String("account.id", string(accountID)),
+		slog.String("start", startDate.Format(monzoTimeFormat)),
+		slog.String("end", endDate.Format(monzoTimeFormat)),
+		slog.Int("limit", limit),
+	)
 
 	for {
 		select {
@@ -228,11 +219,11 @@ func (m *TransactionExporter) fetchTransactions(ctx context.Context, accountID m
 		}
 	}
 
-	zerolog.Ctx(ctx).Debug().
-		Str("bank", Monzo).
-		Str("account.id", string(accountID)).
-		Int("transaction.total", len(transactions)).
-		Msg("fetched Monzo transactions")
+	log.FromContext(ctx).InfoContext(ctx, "fetched transactions",
+		slog.String("bank", Monzo),
+		slog.String("account.id", string(accountID)),
+		slog.Int("transaction.total", len(transactions)),
+	)
 
 	return transactions, nil
 }

--- a/internal/starling/exporter/exporter.go
+++ b/internal/starling/exporter/exporter.go
@@ -63,7 +63,6 @@ func (s *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 	}
 
 	log.FromContext(ctx).InfoContext(ctx, "starting export of transactions",
-		slog.String("bank", Starling),
 		slog.String("export.start", opts.StartDate.Format(starlingTimeFormat)),
 		slog.String("export.end", opts.EndDate.Format(starlingTimeFormat)),
 	)
@@ -81,7 +80,6 @@ func (s *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 	}
 
 	log.FromContext(ctx).InfoContext(ctx, "successfully exported transactions",
-		slog.String("bank", Starling),
 		slog.Int("transaction.count", len(transactions)),
 	)
 
@@ -131,12 +129,10 @@ func (s *TransactionExporter) fetchAccount(ctx context.Context, accountID starli
 	}
 
 	log.FromContext(ctx).InfoContext(ctx, "found accounts",
-		slog.String("bank", Starling),
 		slog.Int("account.total", len(accountIDs)),
 	)
 
 	log.FromContext(ctx).InfoContext(ctx, "selected account",
-		slog.String("bank", Starling),
 		slog.String("account.id", selectedAccount.ID.String()),
 		slog.String("account.category.id", selectedAccount.DefaultCategoryID.String()),
 	)
@@ -146,7 +142,6 @@ func (s *TransactionExporter) fetchAccount(ctx context.Context, accountID starli
 
 func (s *TransactionExporter) fetchTransactionsSince(ctx context.Context, accountID starling.AccountID, categoryID starling.CategoryID, start time.Time, end time.Time) ([]*starling.FeedItem, error) {
 	log.FromContext(ctx).InfoContext(ctx, "fetching transactions",
-		slog.String("bank", Starling),
 		slog.String("account.id", accountID.String()),
 		slog.String("account.category.id", categoryID.String()),
 		slog.String("start", start.Format(starlingTimeFormat)),
@@ -178,7 +173,6 @@ func (s *TransactionExporter) fetchTransactionsSince(ctx context.Context, accoun
 	})
 
 	log.FromContext(ctx).InfoContext(ctx, "fetched transactions",
-		slog.String("bank", Starling),
 		slog.String("account.id", accountID.String()),
 		slog.String("account.category.id", categoryID.String()),
 		slog.Int("transaction.total", len(filteredTransactions)),
@@ -215,7 +209,6 @@ func (s *TransactionExporter) fetchRoundUpTransactions(ctx context.Context, acco
 	roundUpTransactions := make([]*starling.FeedItem, 0)
 
 	log.FromContext(ctx).DebugContext(ctx, "enriching transaction descriptions",
-		slog.String("bank", Starling),
 		slog.String("account.id", accountID.String()),
 	)
 

--- a/internal/starling/exporter/exporter.go
+++ b/internal/starling/exporter/exporter.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/HallyG/fingrab/internal/domain"
 	"github.com/HallyG/fingrab/internal/export"
+	"github.com/HallyG/fingrab/internal/log"
 	"github.com/HallyG/fingrab/internal/starling"
 	"github.com/HallyG/fingrab/internal/util/sliceutil"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -61,11 +62,11 @@ func (s *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 		accountID = starling.AccountID(uuid)
 	}
 
-	zerolog.Ctx(ctx).Info().
-		Str("bank", Starling).
-		Str("export.start", opts.StartDate.Format(starlingTimeFormat)).
-		Str("export.end", opts.EndDate.Format(starlingTimeFormat)).
-		Msg("starting export of Starling transactions")
+	log.FromContext(ctx).InfoContext(ctx, "starting export of transactions",
+		slog.String("bank", Starling),
+		slog.String("export.start", opts.StartDate.Format(starlingTimeFormat)),
+		slog.String("export.end", opts.EndDate.Format(starlingTimeFormat)),
+	)
 
 	account, err := s.fetchAccount(ctx, accountID)
 	if err != nil {
@@ -79,10 +80,10 @@ func (s *TransactionExporter) ExportTransactions(ctx context.Context, opts expor
 		return nil, err
 	}
 
-	zerolog.Ctx(ctx).Info().
-		Str("bank", Starling).
-		Int("transaction.count", len(transactions)).
-		Msg("successfully exported Starling transactions")
+	log.FromContext(ctx).InfoContext(ctx, "successfully exported transactions",
+		slog.String("bank", Starling),
+		slog.Int("transaction.count", len(transactions)),
+	)
 
 	return sliceutil.Map(transactions, func(txn *starling.FeedItem) *domain.Transaction {
 		reference := s.determineReference(txn)
@@ -120,42 +121,37 @@ func (s *TransactionExporter) fetchAccount(ctx context.Context, accountID starli
 	}
 
 	selectedAccount := accounts[0]
-	accountsArr := zerolog.Arr()
-
 	accountIDs := make([]starling.AccountID, 0)
-
 	for _, account := range accounts {
 		if accountID == account.ID {
 			selectedAccount = account
 		}
 
 		accountIDs = append(accountIDs, account.ID)
-		accountsArr.Str(account.ID.String())
 	}
 
-	zerolog.Ctx(ctx).Debug().
-		Str("bank", Starling).
-		Int("account.total", len(accountIDs)).
-		Array("account.all", accountsArr).
-		Msg("found Starling accounts")
+	log.FromContext(ctx).InfoContext(ctx, "found accounts",
+		slog.String("bank", Starling),
+		slog.Int("account.total", len(accountIDs)),
+	)
 
-	zerolog.Ctx(ctx).Info().
-		Str("bank", Starling).
-		Str("account.id", selectedAccount.ID.String()).
-		Str("category.id", selectedAccount.DefaultCategoryID.String()).
-		Msg("selected Starling account")
+	log.FromContext(ctx).InfoContext(ctx, "selected account",
+		slog.String("bank", Starling),
+		slog.String("account.id", selectedAccount.ID.String()),
+		slog.String("account.category.id", selectedAccount.DefaultCategoryID.String()),
+	)
 
 	return selectedAccount, nil
 }
 
 func (s *TransactionExporter) fetchTransactionsSince(ctx context.Context, accountID starling.AccountID, categoryID starling.CategoryID, start time.Time, end time.Time) ([]*starling.FeedItem, error) {
-	zerolog.Ctx(ctx).Info().
-		Str("bank", Starling).
-		Str("account.id", accountID.String()).
-		Str("category.id", categoryID.String()).
-		Time("start", start).
-		Time("end", end).
-		Msg("fetching Starling transactions")
+	log.FromContext(ctx).InfoContext(ctx, "fetching transactions",
+		slog.String("bank", Starling),
+		slog.String("account.id", accountID.String()),
+		slog.String("account.category.id", categoryID.String()),
+		slog.String("start", start.Format(starlingTimeFormat)),
+		slog.String("end", end.Format(starlingTimeFormat)),
+	)
 
 	transactions, err := s.api.FetchTransactionsSince(ctx, starling.FetchTransactionOptions{
 		AccountID:  accountID,
@@ -181,12 +177,12 @@ func (s *TransactionExporter) fetchTransactionsSince(ctx context.Context, accoun
 		return txn.Status != starling.StatusDeclined
 	})
 
-	zerolog.Ctx(ctx).Info().
-		Str("bank", Starling).
-		Str("account.id", accountID.String()).
-		Str("category.id", categoryID.String()).
-		Int("transaction.total", len(filteredTransactions)).
-		Msg("fetched Starling transactions")
+	log.FromContext(ctx).InfoContext(ctx, "fetched transactions",
+		slog.String("bank", Starling),
+		slog.String("account.id", accountID.String()),
+		slog.String("account.category.id", categoryID.String()),
+		slog.Int("transaction.total", len(filteredTransactions)),
+	)
 
 	return filteredTransactions, nil
 }
@@ -217,6 +213,11 @@ func (s *TransactionExporter) determineReference(txn *starling.FeedItem) string 
 func (s *TransactionExporter) fetchRoundUpTransactions(ctx context.Context, accountID starling.AccountID, start time.Time, end time.Time, transactionsWithRoundUp []*starling.FeedItem) ([]*starling.FeedItem, error) {
 	seenCategoryIDs := make(map[starling.CategoryID]struct{})
 	roundUpTransactions := make([]*starling.FeedItem, 0)
+
+	log.FromContext(ctx).DebugContext(ctx, "enriching transaction descriptions",
+		slog.String("bank", Starling),
+		slog.String("account.id", accountID.String()),
+	)
 
 	for _, txn := range transactionsWithRoundUp {
 		if txn.RoundUp == nil {


### PR DESCRIPTION
- Use `slog` instead of `zerolog` to minimise dependencies.
- Add coloured text output for cli.
- Remove formatter logic from `export` package
- Fix issue where you could not export transactions from the current day 