### PR TITLE
Return env var instead of empty option

### DIFF
--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -88,7 +88,7 @@ func getAuthToken(opts *exportOptions, exportType export.ExportType) (string, er
 		return "", fmt.Errorf("authentication token is required. Please provide it via --token flag or %s environment variable", envVar)
 	}
 
-	return opts.AuthToken, nil
+	return authToken, nil
 }
 
 func runExport(ctx context.Context, output io.Writer, opts *exportOptions, exportType export.ExportType) error {


### PR DESCRIPTION
`getAuthToken` always returned an empty string when `opts.AuthToken` is empty, regardless of whether there was an env-var.